### PR TITLE
fix: enable rustls-tls to address webpki security vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ cron_tab = { version = "0.2.13", features = ["async"] }
 env_logger = "0.11.10"
 log = "0.4.29"
 openssl = { version = "0.10.77", features = ["vendored"] }
-reqwest = { version = "0.13.2", features = ["json"] }
+reqwest = { version = "0.13.2", features = ["json", "rustls-tls"] }
 rspotify = { version = "0.16.0", features = ["cli"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"


### PR DESCRIPTION
## Summary

Enables the `rustls-tls` feature in `reqwest` to address two `rustls-webpki` security vulnerabilities:

- **GHSA-xgp8-3hg3-c2mh**: Wildcard name constraints were incorrectly accepted for certificates, allowing `*.example.com` to bypass a `accept.example.com` constraint
- **GHSA-965h-392x-2mh5**: URI name constraints were ignored and incorrectly accepted

Both are fixed in `rustls-webpki >= 0.103.12`.

### Why this works

The project uses `rspotify` which depends on `reqwest`. By default `reqwest` uses `native-tls` which does not depend on `rustls-webpki`. Adding the `rustls-tls` feature switches the TLS backend to `rustls`, which depends on `rustls-webpki`. Dependabot will then be able to update `rustls-webpki` to the patched version.

### Changes

- `Cargo.toml`: Added `rustls-tls` feature to `reqwest`

## Test plan

- [ ] CI build passes (cross-compilation to musl targets)
- [ ] Dependabot subsequently updates `rustls-webpki` to `>= 0.103.12`
- [ ] Security alerts are resolved

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)