### PR TITLE
Add PR workflow for build and test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,29 @@
+name: PR Build and Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        platform:
+          - target: aarch64-unknown-linux-musl
+          - target: i686-unknown-linux-musl
+          - target: x86_64-unknown-linux-musl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build and test binary
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          command: both
+          target: ${{ matrix.platform.target }}
+          args: "--release"
+          strip: true
+        env:
+          CROSS_CONTAINER_OPTS: "-v /var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs on every PR to main
- Runs `cargo build` and `cargo test` across multiple platforms (aarch64, i686, x86_64)

## Test plan
- [ ] PR workflow runs automatically when PR is opened
- [ ] All three platform builds complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)