### PR TITLE
Fix TLS CA certificates error by using native-tls instead of rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ cron_tab = { version = "0.2.13", features = ["async"] }
 env_logger = "0.11.10"
 log = "0.4.29"
 openssl = { version = "0.10.77", features = ["vendored"] }
-reqwest = { version = "0.13.2", features = ["json", "rustls"] }
+reqwest = { version = "0.13.2", features = ["json", "native-tls"] }
 rspotify = { version = "0.16.0", features = ["cli"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"


### PR DESCRIPTION
## Summary

The application panicked at runtime with:
```
thread 'main' (1) panicked at src/slack.rs:49:18
called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

## Root Cause

The `Cargo.toml` configured reqwest with the `rustls` feature, which is a pure-Rust TLS implementation that does not use the system's CA certificate store. When reqwest attempts to make HTTPS connections, it fails because no CA certificates are available.

## Fix

Changed `reqwest` from using `rustls` to `native-tls` in `Cargo.toml`:

```diff
-reqwest = { version = "0.13.2", features = ["json", "rustls"] }
+reqwest = { version = "0.13.2", features = ["json", "native-tls"] }
```

The `native-tls` feature allows reqwest to use the operating system's CA certificate store, which properly resolves the TLS handshake issue.

## Test plan

- [ ] Verify the application compiles successfully
- [ ] Run the application and confirm it no longer panics on startup