### PR TITLE
Fix SSL certificate verification error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ cron_tab = { version = "0.2.13", features = ["async"] }
 env_logger = "0.11.10"
 log = "0.4.29"
 openssl = { version = "0.10.78", features = ["vendored"] }
-reqwest = { version = "0.13.2", features = ["json", "native-tls"] }
+reqwest = { version = "0.13.2", features = ["json", "rustls"] }
 rspotify = { version = "0.16.0", features = ["cli"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"


### PR DESCRIPTION
## Summary

Fix `certificate verify failed` error when connecting to Spotify API.

The error `unable to get local issuer certificate` occurred because the `native-tls` feature relies on the system's OpenSSL certificate store, which may not have the required CA certificates in some deployment environments.

## Fix

Switch from `native-tls` to `rustls` TLS backend in `reqwest`. The `rustls` crate provides TLS with its own certificate verification, independent of the system CA store.

**Before:**
```toml
reqwest = { version = "0.13.2", features = ["json", "native-tls"] }
```

**After:**
```toml
reqwest = { version = "0.13.2", features = ["json", "rustls"] }
```

## Test plan

- [ ] Verify the build compiles successfully
- [ ] Verify the application can authenticate with Spotify API without SSL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)