### PR TITLE
Fix: Use native-tls instead of rustls to resolve CA certificate loading error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ cron_tab = { version = "0.2.13", features = ["async"] }
 env_logger = "0.11.10"
 log = "0.4.29"
 openssl = { version = "0.10.78", features = ["vendored"] }
-reqwest = { version = "0.13.2", features = ["json", "rustls"] }
+reqwest = { version = "0.13.2", features = ["json", "native-tls"] }
 rspotify = { version = "0.16.0", features = ["cli"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"


### PR DESCRIPTION
## Summary
- Switch reqwest TLS backend from `rustls` to `native-tls` to use the system certificate store

## Root Cause
The `rustls` library doesn't load system CA certificates by default, causing HTTPS requests to fail with:
```
called \`Result::unwrap()\` on an \`Err\` value: reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

## Test plan
- [ ] Verify the application builds successfully
- [ ] Verify HTTPS requests to Slack API work correctly
- [ ] Verify HTTPS requests to Spotify API work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)