### PR TITLE
fix: set SSL_CERT_FILE env var for Spotify TLS verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=builder "/etc_passwd" "/etc/passwd"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /usr/local/ssl/ca-certificates.crt
 USER nobody
 
+ENV SSL_CERT_FILE=/usr/local/ssl/ca-certificates.crt
 ENV RUST_LOG=info
 ENV SPOTIFY_CLIENT_ID=your-client-id
 ENV SPOTIFY_CLIENT_SECRET=your-client-secret


### PR DESCRIPTION
## Summary
- Set `SSL_CERT_FILE=/usr/local/ssl/ca-certificates.crt` in Dockerfile so rspotify/reqwest can verify Spotify's TLS certificate

## Root Cause
When running in a scratch Docker image, the application has no access to system CA certificates. The Spotify OAuth token request fails with "unable to get local issuer certificate" because reqwest can't verify the Spotify API's TLS certificate.

## Test plan
- [ ] Verify the Docker image builds successfully
- [ ] Verify the application can connect to Spotify API when deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)